### PR TITLE
Use Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     description: 'Additionnal testssl.sh CLI options'
     default: '--jsonfile /data --csvfile /data --htmlfile /data'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Because 12 is being [deprecated by GitHub](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and running the action logs some warnings.

However I'm not sure this is all that needs to be done, sorry.