### PR TITLE
Allow non-0 exit codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,10 @@ async function run() {
     await exec.exec(`docker pull ${image} -q`);
     let command = (`docker run --user 0:0 -v ${workspace}/${output}:/data --network="host" ` + `-t ${image} ${options} ${host}`);
     try {
-      await exec.exec(command);
+      let execOptions = {
+        ignoreReturnCode: true
+      };
+      await exec.exec(command, [], execOptions);
 
       let path = workspace + '/' + output;
       let reportFile = fs.readdirSync(path).filter(fn => fn.startsWith(host) && fn.endsWith('.json'))[0];


### PR DESCRIPTION
This PR adds an `execOptions` object that is passed to `core.exec()` to allow non-zero exit codes. This is because `testssl.sh` now uses the exit code to signal ambigous results or errors, which can be present during a successful test. This is documented [here](https://github.com/drwetter/testssl.sh/blob/3.2/doc/testssl.1.md#exit-status).